### PR TITLE
Docs/Website: MySQL config parameter should be "verify_connection"

### DIFF
--- a/website/source/docs/secrets/mysql/index.html.md
+++ b/website/source/docs/secrets/mysql/index.html.md
@@ -172,7 +172,7 @@ the default on versions prior to that.
   <dd>
     <ul>
       <li>
-        <span class="param">verify-connection</span>
+        <span class="param">verify_connection</span>
         <span class="param-flags">optional</span>
 	If set, connection_url is verified by actually connecting to the database.
 	Defaults to true.


### PR DESCRIPTION
Currently, the docs show `verify-connection`.

The only instance of `verify-connection` I can find is on this docs page. The API style for parameters is underscores, so this one stands out.

The code for this and the other backends with similar connection verification features seem to use `verify_connection`.

This was discovered on 0.6.1 where a test system was being provisioned with vault and mysql in a single Packer build. MySQL had not yet been started, so the db service was not available in Consul.

Possibly a separate issue:

Even with `verify_connection: false` in the body of the request to `mysql/config/connection` and where the mysql server is not yet started and/or available in consul, I still get an HTTP 400 with the following message:

```
"json": {"errors": ["Error testing query: dial tcp: lookup db.service.consul on 192.168.1.1:53: no such host"]...
```

My expectation was that the backend could be configured without the mysql server being available
when using `verify_connection: false`.
